### PR TITLE
Update dependencies and block entity logic

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@ version = 1.0.0
 desc = example
 
 # Cosmic Reach
-cosmic_reach_version = 0.5.1-alpha
-cosmic_reach_minimum_version = 0.4.17-alpha
+cosmic_reach_version = 0.5.7-alpha
+cosmic_reach_minimum_version = 0.5.6-alpha
 
 # Puzzle Loader
-puzzle_cosmic_version = 1.4.2-alpha
-puzzle_core_version = 1.1.2-alpha
+puzzle_cosmic_version = 1.5.2-alpha
+puzzle_core_version = 1.3.4-alpha
+
+# Puzzle Gradle
+jigsaw_gradle_version = 2.0.7
 
 # Cosmic API
 cosmic_api_version = 1.3.6-0.5.1
-
-# Puzzle Gradle
-jigsaw_gradle_version = 2.0.6

--- a/src/main/java/org/example/exmod/block_entities/ExampleBlockEntity.java
+++ b/src/main/java/org/example/exmod/block_entities/ExampleBlockEntity.java
@@ -42,8 +42,8 @@ public class ExampleBlockEntity extends AbstractCosmicBlockEntity {
     public void onTick() {
         BlockPosition above = BlockPosition.ofGlobal(zone, x, y, z).getOffsetBlockPos(zone, 0, 1, 0);
         BlockState current = above.getBlockState();
-        if(current.getBlock() == Block.AIR) {
-            BlockSetter.get().replaceBlock(zone, Block.GRASS.getDefaultBlockState(), above);
+        if(current.getBlock() == Block.getById("base:air")) {
+            BlockSetter.get().replaceBlock(zone, Block.getById("base:grass").getDefaultBlockState(), above);
         }
     }
 


### PR DESCRIPTION
Bumped versions for Cosmic Reach, Puzzle Loader, and Puzzle Gradle in gradle.properties. Refactored ExampleBlockEntity to use Block.getById for air and grass block checks and replacements, improving compatibility with block registry changes.